### PR TITLE
Issue 5: Fix path for mounted secrets files

### DIFF
--- a/horizon/deployment.policy.json
+++ b/horizon/deployment.policy.json
@@ -23,9 +23,9 @@
       "serviceUrl": "$SERVICE_NAME",
       "serviceVersionRange": "[0.0.0,INFINITY)",
       "inputs": [
-        {"name":"POSTGRES_PASSWORD_FILE","value":"/secret_password"},
-        {"name":"POSTGRES_USER_FILE","value":"/secret_user"},
-        {"name":"POSTGRES_DB_FILE","value":"/secret_db"}
+        {"name":"POSTGRES_PASSWORD_FILE","value":"/open-horizon-secrets/secret_password"},
+        {"name":"POSTGRES_USER_FILE","value":"/open-horizon-secrets/secret_user"},
+        {"name":"POSTGRES_DB_FILE","value":"/open-horizon-secrets/secret_db"}
       ]
     }
   ],

--- a/horizon/service.definition.json
+++ b/horizon/service.definition.json
@@ -14,19 +14,19 @@
 			"name": "POSTGRES_PASSWORD_FILE",
 			"label": "Password file",
 			"type": "string",
-			"defaultValue": "/SecretName"
+			"defaultValue": "/open-horizon-secrets/SecretName"
 		},
         {
 			"name": "POSTGRES_USER_FILE",
 			"label": "Username file",
 			"type": "string",
-			"defaultValue": "/SecretName"
+			"defaultValue": "/open-horizon-secrets/SecretName"
 		},
         {
 			"name": "POSTGRES_DB_FILE",
 			"label": "Database Name file",
 			"type": "string",
-			"defaultValue": "/SecretName"
+			"defaultValue": "/open-horizon-secrets/SecretName"
 		}
     ],
     "deployment": {


### PR DESCRIPTION
Changed path from `/` to `/open-horizon-secrets/`