### PR TITLE
Issue #10: Remove agent-run command from publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ build:
 push:
 	@echo "There is no Docker image push process since this container is provided by a third-party from official sources."
 
-publish: publish-service publish-deployment-policy agent-run
+publish: publish-service publish-deployment-policy
 
 # Pull, not push, Docker image since provided by third party
 publish-service:


### PR DESCRIPTION
This PR removes the 'agent-run' command from the 'publish' target in the Makefile to prevent automatic node registration during the publish process. Closes #10.